### PR TITLE
任意のディレクトリにレポジトリを置くことができるように変更.

### DIFF
--- a/mklink.sh
+++ b/mklink.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-ln -sf ~/dotfiles/.vimrc ~/.vimrc
+repopath=$(cd $(dirname $0); pwd)
+
+ln -sf $repopath/.vimrc $HOME/.vimrc
 


### PR DESCRIPTION
以下コマンドを使うと，現在のシェル`mklink.sh`までの絶対パスが取得できるので，そのパスを基準に処理を行うと，任意のディレクトリにレポジトリをcloneすることができて楽です．[参考](https://qiita.com/koara-local/items/2d67c0964188bba39e29)
```shell
$(cd $(dirname $0); pwd)
```

また，チルダ(~)はダブルクォートで囲われると展開されないという制限が存在します．[参考](https://ja.stackoverflow.com/questions/22264/%E3%82%B7%E3%82%A7%E3%83%AB%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88%E3%81%A7%E5%90%8D%E5%89%8D%E3%81%AB%E7%A9%BA%E7%99%BD%E3%82%92%E5%90%AB%E3%82%80%E3%83%87%E3%82%A3%E3%83%AC%E3%82%AF%E3%83%88%E3%83%AA%E3%81%AB%E5%AF%BE%E3%81%97%E3%81%A6%E4%BD%9C%E6%A5%AD%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
環境変数`$HOME`を使うことで，空白を含むパスを操作するときに""で囲っても正常に動作します．
```shell
ln -sf $repopath/.vimrc $HOME/.vimrc
```